### PR TITLE
Fix using subscription in container

### DIFF
--- a/4.1/Dockerfile.rhel7
+++ b/4.1/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhel7:7.2
+FROM rhel7
 
 LABEL io.k8s.description="Platform for building and running Ruby on Rails 4.1 applications" \
       io.k8s.display-name="Ruby on Rails 4.1"
@@ -22,6 +22,8 @@ ENV BASH_ENV=/opt/app-root/etc/scl_enable \
     PROMPT_COMMAND=". /opt/app-root/etc/scl_enable"
 
 # Let's install the same as STI images
+# To use subscription inside container yum command has to be run first (before yum-config-manager)
+# https://access.redhat.com/solutions/1443553
 RUN yum install -y --setopt=tsflags=nodocs \
   autoconf \
   automake \
@@ -64,7 +66,10 @@ EXPOSE 8080
 
 ENV RAILS_VERSION 4.1
 
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# To use subscription inside container yum command has to be run first (before yum-config-manager)
+# https://access.redhat.com/solutions/1443553
+RUN yum repolist > /dev/null && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     INSTALL_PKGS="rh-ruby22 rh-ruby22-ruby-devel rh-ruby22-rubygem-rake v8314 rh-ruby22-rubygem-bundler rh-ror41 nodejs010" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/4.2/Dockerfile.rhel7
+++ b/4.2/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhel7:7.2
+FROM rhel7
 
 LABEL io.k8s.description="Platform for building and running Ruby on Rails 4.2 applications" \
       io.k8s.display-name="Ruby on Rails 4.2"
@@ -22,6 +22,8 @@ ENV BASH_ENV=/opt/app-root/etc/scl_enable \
     PROMPT_COMMAND=". /opt/app-root/etc/scl_enable"
 
 # Let's install the same as STI images
+# To use subscription inside container yum command has to be run first (before yum-config-manager)
+# https://access.redhat.com/solutions/1443553
 RUN yum install -y --setopt=tsflags=nodocs \
   autoconf \
   automake \
@@ -64,7 +66,10 @@ EXPOSE 8080
 
 ENV RAILS_VERSION 4.2
 
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# To use subscription inside container yum command has to be run first (before yum-config-manager)
+# https://access.redhat.com/solutions/1443553
+RUN yum repolist > /dev/null && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     INSTALL_PKGS="rh-ror42 rh-ruby23-ruby-devel rh-nodejs4" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \


### PR DESCRIPTION
Enabling host repositories didn't work with docker 1.10 and newer inside OpenStack. It was fixed in latest rhel7 base release, so using 'rhel7' base image is required for RHEL CI. Postgresql PR - sclorg/postgresql-container#150

Also to enable repositories inside container running 'yum' first is required - see https://access.redhat.com/solutions/1443553 . Similar to sclorg/s2i-base-container#99 .


@hhorak @bparees Please take a look and merge.