### PR TITLE
Update Dockerfiles

### DIFF
--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -9,7 +9,11 @@ It contains Ruby 2.2, Ruby on Rails 4.1, and NodeJS 0.10 preinstalled."
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$SUMMARY" \
-      io.k8s.display-name="Ruby on Rails 4.1"
+      io.k8s.display-name="Ruby on Rails 4.1" \
+      com.redhat.component="rh-ror41-docker" \
+      name="centos/ror-41-centos7" \
+      version="4.1" \
+      release="1"
 
 # The following is taken from STI base image so this Dockerfile follows the same convetions.
 # https://github.com/openshift/sti-base/blob/master/Dockerfile

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -22,8 +22,7 @@ ENV BASH_ENV=/opt/app-root/etc/scl_enable \
     PROMPT_COMMAND=". /opt/app-root/etc/scl_enable"
 
 # Let's install the same as STI images
-RUN yum install -y --setopt=tsflags=nodocs \
-  autoconf \
+RUN INSTALL_PKGS="autoconf \
   automake \
   findutils \
   gcc-c++ \
@@ -48,7 +47,9 @@ RUN yum install -y --setopt=tsflags=nodocs \
   wget \
   which \
   yum-utils \
-  zlib-devel && \
+  zlib-devel" && \
+  yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
   yum clean all -y && \
   mkdir -p ${HOME} && \
   groupadd -r default -f -g 1001 && \

--- a/4.1/Dockerfile.rhel7
+++ b/4.1/Dockerfile.rhel7
@@ -9,14 +9,11 @@ It contains Ruby 2.2, Ruby on Rails 4.1, and NodeJS 0.10 preinstalled."
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$SUMMARY" \
-      io.k8s.display-name="Ruby on Rails 4.1"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-ror41-docker" \
+      io.k8s.display-name="Ruby on Rails 4.1" \
+      com.redhat.component="rh-ror41-docker" \
       name="rhscl/ror-41-rhel7" \
       version="4.1" \
-      release="13.3" \
-      architecture="x86_64"
+      release="13.3"
 
 # The following is taken from STI base image so this Dockerfile follows the same convetions.
 # https://github.com/openshift/sti-base/blob/master/Dockerfile

--- a/4.1/Dockerfile.rhel7
+++ b/4.1/Dockerfile.rhel7
@@ -31,8 +31,7 @@ ENV BASH_ENV=/opt/app-root/etc/scl_enable \
 # Let's install the same as STI images
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553
-RUN yum install -y --setopt=tsflags=nodocs \
-  autoconf \
+RUN INSTALL_PKGS="autoconf \
   automake \
   findutils \
   gcc-c++ \
@@ -57,7 +56,9 @@ RUN yum install -y --setopt=tsflags=nodocs \
   wget \
   which \
   yum-utils \
-  zlib-devel && \
+  zlib-devel" && \
+  yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
   yum clean all -y && \
   mkdir -p ${HOME} && \
   groupadd -r default -f -g 1001 && \

--- a/4.1/root/usr/share/container-scripts/ror/README.md
+++ b/4.1/root/usr/share/container-scripts/ror/README.md
@@ -16,7 +16,7 @@ docker pull registry.access.redhat.com/rhscl/ror-41-rhel7
 To create a layered container image that uses this image as base, create a Dockerfile as the following:
 ```
 FROM registry.access.redhat.com/rhscl/ror-41-rhel7
-ADD your-app /opt/app-root/src
+COPY your-app /opt/app-root/src
 CMD ...
 ```
 

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -9,7 +9,11 @@ It contains Ruby 2.3, Ruby on Rails 4.2, and NodeJS 4 preinstalled."
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$SUMMARY" \
-      io.k8s.display-name="Ruby on Rails 4.2"
+      io.k8s.display-name="Ruby on Rails 4.2" \
+      com.redhat.component="rh-ror42-docker" \
+      name="centos/ror-42-centos7" \
+      version="4.2" \
+      release="1"
 
 # The following is taken from STI base image so this Dockerfile follows the same convetions.
 # https://github.com/openshift/sti-base/blob/master/Dockerfile

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -22,8 +22,7 @@ ENV BASH_ENV=/opt/app-root/etc/scl_enable \
     PROMPT_COMMAND=". /opt/app-root/etc/scl_enable"
 
 # Let's install the same as STI images
-RUN yum install -y --setopt=tsflags=nodocs \
-  autoconf \
+RUN INSTALL_PKGS="autoconf \
   automake \
   findutils \
   gcc-c++ \
@@ -48,7 +47,9 @@ RUN yum install -y --setopt=tsflags=nodocs \
   wget \
   which \
   yum-utils \
-  zlib-devel && \
+  zlib-devel" && \
+  yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
   yum clean all -y && \
   mkdir -p ${HOME} && \
   groupadd -r default -f -g 1001 && \

--- a/4.2/Dockerfile.rhel7
+++ b/4.2/Dockerfile.rhel7
@@ -9,14 +9,11 @@ It contains Ruby 2.3, Ruby on Rails 4.2, and NodeJS 4 preinstalled."
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$SUMMARY" \
-      io.k8s.display-name="Ruby on Rails 4.2"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-ror42-docker" \
+      io.k8s.display-name="Ruby on Rails 4.2" \
+      com.redhat.component="rh-ror42-docker" \
       name="rhscl/ror-42-rhel7" \
       version="4.2" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 # The following is taken from STI base image so this Dockerfile follows the same convetions.
 # https://github.com/openshift/sti-base/blob/master/Dockerfile

--- a/4.2/Dockerfile.rhel7
+++ b/4.2/Dockerfile.rhel7
@@ -31,8 +31,7 @@ ENV BASH_ENV=/opt/app-root/etc/scl_enable \
 # Let's install the same as STI images
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553
-RUN yum install -y --setopt=tsflags=nodocs \
-  autoconf \
+RUN INSTALL_PKGS="autoconf \
   automake \
   findutils \
   gcc-c++ \
@@ -57,7 +56,9 @@ RUN yum install -y --setopt=tsflags=nodocs \
   wget \
   which \
   yum-utils \
-  zlib-devel && \
+  zlib-devel" && \
+  yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
   yum clean all -y && \
   mkdir -p ${HOME} && \
   groupadd -r default -f -g 1001 && \

--- a/4.2/root/usr/share/container-scripts/ror/README.md
+++ b/4.2/root/usr/share/container-scripts/ror/README.md
@@ -16,7 +16,7 @@ docker pull centos/ror-42-centos7
 To create a layered container image that uses this image as base, create a Dockerfile as the following:
 ```
 FROM centos/ror-42-centos7
-ADD your-app /opt/app-root/src
+COPY your-app /opt/app-root/src
 CMD ...
 ```
 

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -9,7 +9,11 @@ It contains Ruby 2.4, Ruby on Rails 5.0, and NodeJS 6 preinstalled."
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$SUMMARY" \
-      io.k8s.display-name="Ruby on Rails 5.0"
+      io.k8s.display-name="Ruby on Rails 5.0" \
+      com.redhat.component="rh-ror50-docker" \
+      name="centos/ror-50-centos7" \
+      version="5.0" \
+      release="1"
 
 # The following is taken from STI base image so this Dockerfile follows the same convetions.
 # https://github.com/openshift/sti-base/blob/master/Dockerfile

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -22,8 +22,7 @@ ENV BASH_ENV=/opt/app-root/etc/scl_enable \
     PROMPT_COMMAND=". /opt/app-root/etc/scl_enable"
 
 # Let's install the same as STI images
-RUN yum install -y --setopt=tsflags=nodocs \
-  autoconf \
+RUN INSTALL_PKGS="autoconf \
   automake \
   findutils \
   gcc-c++ \
@@ -48,7 +47,9 @@ RUN yum install -y --setopt=tsflags=nodocs \
   wget \
   which \
   yum-utils \
-  zlib-devel && \
+  zlib-devel" && \
+  yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
   yum clean all -y && \
   mkdir -p ${HOME} && \
   groupadd -r default -f -g 1001 && \

--- a/5.0/Dockerfile.rhel7
+++ b/5.0/Dockerfile.rhel7
@@ -31,8 +31,7 @@ ENV BASH_ENV=/opt/app-root/etc/scl_enable \
 # Let's install the same as STI images
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553
-RUN yum install -y --setopt=tsflags=nodocs \
-  autoconf \
+RUN INSTALL_PKGS="autoconf \
   automake \
   findutils \
   gcc-c++ \
@@ -57,7 +56,9 @@ RUN yum install -y --setopt=tsflags=nodocs \
   wget \
   which \
   yum-utils \
-  zlib-devel && \
+  zlib-devel" && \
+  yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
   yum clean all -y && \
   mkdir -p ${HOME} && \
   groupadd -r default -f -g 1001 && \

--- a/5.0/Dockerfile.rhel7
+++ b/5.0/Dockerfile.rhel7
@@ -9,14 +9,11 @@ It contains Ruby 2.4, Ruby on Rails 5.0, and NodeJS 6 preinstalled."
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$SUMMARY" \
-      io.k8s.display-name="Ruby on Rails 5.0"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-ror50-docker" \
+      io.k8s.display-name="Ruby on Rails 5.0" \
+      com.redhat.component="rh-ror50-docker" \
       name="rhscl/ror-50-rhel7" \
       version="5.0" \
-      release="2.1" \
-      architecture="x86_64"
+      release="2.1"
 
 # The following is taken from STI base image so this Dockerfile follows the same convetions.
 # https://github.com/openshift/sti-base/blob/master/Dockerfile

--- a/5.0/root/usr/share/container-scripts/ror/README.md
+++ b/5.0/root/usr/share/container-scripts/ror/README.md
@@ -16,7 +16,7 @@ docker pull centos/ror-50-centos7
 To create a layered container image that uses this image as base, create a Dockerfile as the following:
 ```
 FROM centos/ror-50-centos7
-ADD your-app /opt/app-root/src
+COPY your-app /opt/app-root/src
 CMD ...
 ```
 


### PR DESCRIPTION
Use COPY instruction instead of ADD
(COPY is preffered for simple usage - see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy)

Provide same labels for all base image variants (CentOS, RHEL, Fedora)
 - follow recomended labels from Project Atomic Container best practices
 - remove architecture label for RHEL based images (this label is set in RHEL image - no need to define it again)
    
(don't use separate instruction for each label)
Verify installed packages by `rpm -V`.

@hhorak @praiskup @pkubatrh Please take a look and merge.