### PR TITLE
Fix 404 url

### DIFF
--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -17,7 +17,7 @@ LABEL summary="$SUMMARY" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # The following is taken from STI base image so this Dockerfile follows the same convetions.
-# https://github.com/openshift/sti-base/blob/master/Dockerfile
+# https://github.com/sclorg/s2i-base-container/blob/master/core/Dockerfile
 
 ENV HOME=/opt/app-root/src \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/4.1/Dockerfile.rhel7
+++ b/4.1/Dockerfile.rhel7
@@ -17,7 +17,7 @@ LABEL summary="$SUMMARY" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # The following is taken from STI base image so this Dockerfile follows the same convetions.
-# https://github.com/openshift/sti-base/blob/master/Dockerfile
+# https://github.com/sclorg/s2i-base-container/blob/master/core/Dockerfile
 
 ENV HOME=/opt/app-root/src \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -17,7 +17,7 @@ LABEL summary="$SUMMARY" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # The following is taken from STI base image so this Dockerfile follows the same convetions.
-# https://github.com/openshift/sti-base/blob/master/Dockerfile
+# https://github.com/sclorg/s2i-base-container/blob/master/core/Dockerfile
 
 ENV HOME=/opt/app-root/src \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/4.2/Dockerfile.rhel7
+++ b/4.2/Dockerfile.rhel7
@@ -17,7 +17,7 @@ LABEL summary="$SUMMARY" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # The following is taken from STI base image so this Dockerfile follows the same convetions.
-# https://github.com/openshift/sti-base/blob/master/Dockerfile
+# https://github.com/sclorg/s2i-base-container/blob/master/core/Dockerfile
 
 ENV HOME=/opt/app-root/src \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -17,7 +17,7 @@ LABEL summary="$SUMMARY" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # The following is taken from STI base image so this Dockerfile follows the same convetions.
-# https://github.com/openshift/sti-base/blob/master/Dockerfile
+# https://github.com/sclorg/s2i-base-container/blob/master/core/Dockerfile
 
 ENV HOME=/opt/app-root/src \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/5.0/Dockerfile.rhel7
+++ b/5.0/Dockerfile.rhel7
@@ -17,7 +17,7 @@ LABEL summary="$SUMMARY" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # The following is taken from STI base image so this Dockerfile follows the same convetions.
-# https://github.com/openshift/sti-base/blob/master/Dockerfile
+# https://github.com/sclorg/s2i-base-container/blob/master/core/Dockerfile
 
 ENV HOME=/opt/app-root/src \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
https://github.com/openshift/sti-base to https://github.com/sclorg/s2i-base-container

Also, $REPO/Dockerfile has moved to $REPO/core/Dockerfile in PR https://github.com/sclorg/s2i-base-container/pull/121/files#diff-c77761c905bf514492ff1a8fdc8c313b